### PR TITLE
Ajout description succincte du programme Betagouv

### DIFF
--- a/CR_20200706.md
+++ b/CR_20200706.md
@@ -6,70 +6,75 @@
 
 ---
 
-# 1er CR de la commission numérique, si je puis dire.
+# 1er CR de la commission numérique.
+Présents: Arnaud, Marie, Nathalie et Thomas
 
-A été rapporté par Arnaud Nathalie Marie et Thomas .
+## Accompagnement BetaGouv
+BetaGouv, l'incubateur des services numériques, propose un accompagnement dans l'élaboration d'un projet numérique sur 9 semaines. A l'issue de cette phase dite d'investigation, un financement de 200 000 euros peut être proposé pour concrétiser le projet sur une période de 6 mois.
 
-###  Une plateforme d'état, beta-Gouv propose un accompagnement de 9 semaines et à l'issue 6 mois de dev.
-
-il s'agit d'un effort de l'état qui doit découler sur une déclinaison de l'outil a d'autre structures.
-une startup d'état.
-
-appuyé sur le document suivant :
-
-RAPPORT SUR LES DISPOSITIFS
-D’ACCOMPAGNEMENT DES
-COLLECTIVITES LOCALES A
-L’OUVERTURE DES DONNEES PUBLIQUES.
-_A l’attention de Madame la Ministre Axelle LEMAIRE oct 2016_
-
-## nous proposons une réponse à l'investissement de 200 OOO euros pour 6 mois, que l'état mettrai à disposition du projet.
-
-il s'agit donc de faire des passerelles entre des outils que nous utilisons déjà, mais du coté du monde du libre.
-
-à savoir 
-
-	Ø Decidim
-	Ø Mattermost(slack)
-	Ø Tchap(messagerie d'etat)
-	Ø Umap
-	Ø Openstreetmap
-	Ø Zimbra
-	* nextcloud
+Le projet est porté par un "intrapreneur", un agent public désireux de la mise en place d'un service numérique.
 
 
-mettre en flux de travail, dans une application portable, les workflow décisionnels propre à la citoyenneté allant de l'identification au vote en passant par la gestion de projet ou les contributions, mais aussi la visualisation des données et la facilitation de leurs exploitation par les forces citoyennes.
+
+## Projet de plateforme numérique locale
+Nous pensons qu'il serait opportun de répondre à cet appel de BetaGouv.
+
+Le collectif (dont est issue la liste Auray Ville Citoyenne) a utilisé pendant la campagne, des services numériques d'échange, d'édition collaborative et de stockage en ligne. La période de confinement a renforcé leur usage et démontré leur intérêt pour assurer la continuité dans les travaux menés par le collectif.
+
+L'efficacité de ces outils motive aujourd'hui à continuer leur utilisation dans le cadre de la relation entre les élus du conseil municipal, les services de la Ville, les citoyens.
+
+Si le collectif a utilisé des outils développés par des entreprises commerciales, les missions remplies devraient, dans un tel cadre, l'être par des logiciels dits libres, dont l'accès au code est régi par des licences dites open-source.
+
+Le programme d'accompagnement de 6 mois par BetaGouv permettrait la mise en place de process simples de construction et de diffusion de documents numériques, en prenant en compte les réglementations et directives sur le numérique, notamment les obligations de publication en ligne des documents administratifs ainsi que le respect des données personnelles.
+
+Le monde du logiciel libre propose des alternatives aux produits commerciaux utilisés par le collectif. Toutefois, un gap dans la qualité des produits a été constatée. Certaines fonctionnalités ne sont pas présentes. Enfin, si chaque outil répond à un besoin, leur interconnexion permettrait de formaliser des process de construction et de diffusion des documents numériques.
+
+Le collectif a utilisé principalement les outils:
+- Slack;
+- Google Drive;
+- Etherpad (sous divers hébergeurs dont Framapad), Paper;
+- Ethercalc;
+- Zoom;
+- UMap.
+
+Le projet numérique pourrait effectuer une transposition des fonctions remplies par ces outils commerciaux dans le monde du libre:
+- Mattermost;
+- Nextcloud (déjà en place dans les services de la mairie);
+- Edition collaborative proposée par Nextcloud;
+- Jitsi.
+
+Des outils dits de démocratie participative tels que Decidim pourraient à terme être intégrés à cette chaîne.
+
+Enfin, il est à noter qu'une messagerie instantanée de type Whatsapp, Signal développée par les services de l'Etat existe et pourrait contribuer à élargir les capacités d'une telle plateforme.
+
+Mettre en flux de travail, dans une application portable, les workflow décisionnels propre à la citoyenneté allant de l'identification au vote en passant par la gestion de projet ou les contributions, mais aussi la visualisation des données et la facilitation de leur exploitation par les forces citoyennes.
 
 La méthode de fonctionnement s'appuierait sur l'UX (Ux commando : interface au dessus des outils préexistants) d'ampleur communale. Je ne rentre pas dans les détails techniques.
 
-C'est avant tout répondre à la question : comment faire pour que les citoyens utilisent les données ouvertes par la ville et génèrent de la plus value.
+### Objectifs 
+- Assurer la continuité des méthodes de communication utilisées par le collectif dont est issu la liste Auray Ville Citoyenne dans le cadre de la Ville;
+- Accompagner les entreprises et les citoyens dans l'utilisation des données ouvertes (dynamisme social).
 
-Nous croyons  que cela créera du dynamisme social.
-Mm si on passe pas les 9 semaines on aura été coaché.
+Mm si on passe pas les 9 semaines, on aura été coaché.
 
- Conclusion:
+## Conclusion
+La proposition d'accompagnement par Betagouv est une réelle opportunité pour la ville. Même si le projet n'est finalement pas retenu, les 9 semaines d'investigation auront permis d'affiner les besoins de la Mairie en termes d'outils numériques.
 
-	Nous proposons donc de rédiger le document a rendre avant le 26 juillet pour être prioritaire.
-	
-	
-	
-	*Une vision holistique des outils*
- 
- 
-	- A Faire valider par le groupe
- 
-	- promouvoir la création des Règles du groupe municipale basé sur la rédaction de "proposals Gités"
-	
-	- Réunion avec le groupe démocratie participative.
- 
+Nous proposons donc de rédiger un document à rendre avant le 26 juillet, afin que le dossier soit traité en priorité, tel que stipulé par BetaGouv.
 
-#### N'a pas été abordé : 
-le moratoire sur la vidéo surveillance
-5G
-Vélo électriques (numérique ;))
-
-#### Annexes : 
-https://blog.beta.gouv.fr/dinsic/2020/06/22/investigations/
-Opendata France
+*Une vision holistique des outils*
  
-Fing
+- A faire valider par le groupe
+- Promouvoir la création des Règles du groupe municipal basé sur la rédaction de "proposals Gités"
+- Réunion avec le groupe démocratie participative
+
+#### Acteurs pouvant accompagner une telle démarche
+La FING
+OpenDataFrance
+
+#### Références 
+[Accompagnement BetaGouv](https://blog.beta.gouv.fr/dinsic/2020/06/22/investigations/)
+
+[Rapport sur les dispositifs d’accompagnement des collectivités locales à l’ouverture des données publiques](https://www.economie.gouv.fr/files/files/PDF/Rapport__dispositifs_accompagnement_collloc_V1.0.pdf)
+
+


### PR DESCRIPTION
Reprise de la mise en page du document

Cette réunion n’avait comme seul objectif d’envisager une réponse au programme mis en place par Betagouv. J’ai supprimé la section Sujets non abordés dès lors qu’ils n’étaient pas à l’ordre du jour de cette réunion.

Je suis gêné par le fait que l’on considère cette réunion comme la première de la commission Numérique. Ce n’est en aucune manière le cas.